### PR TITLE
modifying how repository urls are grabbed for sync job

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,7 +49,14 @@ def _list_pulp_python_repositories(instance_host: str, *, username: str, passwor
         simple_repository = (
             f"{result['base_url']}simple" if result["base_url"].endswith("/") else f"{result['base_url']}/simple"
         )
-        yield urlunparse(("https", instance_host, simple_repository, "", "", ""))
+
+        index = -1
+        for i in range(0, 3):
+            index = simple_repository.find("/", index + 1)
+        if instance_host[-1:] == "/":
+            yield urlunparse(("https", instance_host, simple_repository[index + 1 :], "", "", ""))
+        else:
+            yield urlunparse(("https", instance_host, simple_repository[index:], "", "", ""))
 
 
 @click.command()


### PR DESCRIPTION
## Related Issues and Dependencies

Addresses Newly registered Python indexes are wrong #33 

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Modifying repo URLs so that internal API url is not included with where repository URLs should be called

## Description

Script begins by calling to [operate-first pulp](https://pulp.operate-first.cloud/pulp/api/v3/distributions/python/pypi) to find all packages hosted on operate-first index. It would grab the `results.base_url` property which would look something like this url: `https://pulp-api-5c5f4669d8-qgvvh/pypi/gym-donkeycar/` (example for gym-donkeycar) and would attempt to [unparse the url](https://github.com/thoth-station/pulp-pypi-sync-job/blob/master/app.py#L52) onto the pulp instance, resulting in something akin to the output logs in [issue 33](#33). The `base_url` points to the pulp-api pod, however seeing as we want to run this on job on test (OCP4) and prod (Smaug) but only have one hosted instance of pulp (on Smaug), we should use its publicly accessible counterpart path on `https://pulp.operate-first.cloud`, which in this example would be `https://pulp.operate-first.cloud/pypi/gym-donkeycar/simple`.