### PR TITLE
adding deploy command to aicoe-ci.yaml

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -8,3 +8,8 @@ build:
   registry-org: thoth-station
   registry-project: pulp-pypi-sync-job
   registry-secret: thoth-station-thoth-pusher-secret
+deploy:
+  image-name: 'pulp-pypi-sync-job'
+  overlay-contextpath: 'pulp-pypi-sync-job/overlays/test/imagestreamtag.yaml'
+  project-name: thoth-application
+  project-org: thoth-station


### PR DESCRIPTION
## Related Issues and Dependencies

Does not directly address [issue 33](https://github.com/thoth-station/pulp-pypi-sync-job/issues/33) as the code changes for this have already been merged, however, it deals with infrastructure to deploy changes in this repository.

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Adding a deploy command so image changes will automatically be staged to test overlay in thoth-station/thoth-application.

## Description

Should the aicoe-ci.yaml file be structured to build to [all overlays](https://github.com/thoth-station/thoth-application/tree/master/pulp-pypi-sync-job/overlays), instead of just to test?
